### PR TITLE
Fix: NullPointerException when antiswear is disabled

### DIFF
--- a/src/main/java/net/zithium/deluxehub/module/modules/chat/AntiSwear.java
+++ b/src/main/java/net/zithium/deluxehub/module/modules/chat/AntiSwear.java
@@ -46,6 +46,8 @@ public class AntiSwear extends Module {
             return;
         }
 
+		if (blockedWords == null)
+			return ;
         for (String word : blockedWords) {
             if (message.toLowerCase().contains(word.toLowerCase())) {
                 cancelAction.run();


### PR DESCRIPTION
Hey,
i had an issue with anti swear disabled. It make the blockedWords variable as null and the code tried to iterate on it.
I has been fixed in this PR

2 lines edited.
Thank you for taking time to read this and have a nice day !